### PR TITLE
Updated helper references to Ghost v1.6.0 to enable successful import to Ghost(Pro)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Steam",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A clean and minimal theme for Ghost.",
   "author": "Tommaso Barbato",
   "homepage": "https://github.com/epistrephein/Steam"

--- a/partials/post-author.hbs
+++ b/partials/post-author.hbs
@@ -1,6 +1,6 @@
 <section class="author">
-    {{#if author.image}}
-        <div class="authorimage" style="background: url({{author.image}})"></div>
+    {{#if author.profile_image}}
+        <div class="authorimage" style="background: url({{author.profile_image}})"></div>
     {{else}}
         <div class="authorimage" style="background: url({{asset "img/default-avatar.png"}})"></div>
     {{/if}}


### PR DESCRIPTION
Importing 1.5.0 into Ghost(Pro) generated the following fatal errors. Updated helper references so import would succeed.

* Replace the {{author.image}} helper with {{author.profile_image}}
  * Affected files:
    * partials/post-author.hbs: Please remove or replace {{author.image}} from this template
* Replace the {{#if author.image}} helper with {{#if author.profile_image}}
  * Affected files:
    * partials/post-author.hbs: Please remove or replace {{#if author.image}} from this template