### PR TITLE
Fix theme to be Ghost 2.0 compatible

### DIFF
--- a/assets/css/steam.css
+++ b/assets/css/steam.css
@@ -277,6 +277,18 @@ img.userimage {
   margin-right: 10px;
   float: left;
 }
+/* Image size options */
+section.post-content .kg-width-wide img {
+}
+section.post-content .kg-width-full img {
+}
+/* Image Gallery Card */
+.kg-gallery-container {
+}
+.kg-gallery-row {
+}
+.kg-gallery-image {
+}
 /* === Footer === */
 footer {
   background: rgba(0, 0, 0, 0.05);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/epistrephein"
     },
     "engines": {
-        "ghost": ">=1.0.0"
+        "ghost": ">=2.1.0"
     },
     "screenshots": {
         "desktop": "assets/screenshots/screenshot-desktop.jpg",
@@ -19,6 +19,7 @@
     "keywords": [
         "ghost",
         "theme",
+        "ghost-theme",
         "minimal",
         "responsive"
     ],

--- a/partials/post-author.hbs
+++ b/partials/post-author.hbs
@@ -1,13 +1,13 @@
 <section class="author">
-    {{#if author.profile_image}}
-        <div class="authorimage" style="background: url({{author.profile_image}})"></div>
+    {{#if primary_author.profile_image}}
+        <div class="authorimage" style="background: url({{primary_author.profile_image}})"></div>
     {{else}}
         <div class="authorimage" style="background: url({{asset "img/default-avatar.png"}})"></div>
     {{/if}}
-    <h4 class="author-name">{{author.name}}</h4>
-    <p class="bio">{{author.bio}}</p>
+    <h4 class="author-name">{{primary_author.name}}</h4>
+    <p class="bio">{{primary_author.bio}}</p>
     <p class="meta">
-      {{#if author.website}}<i class="fa fa-fw fa-globe"></i> <a href="{{author.website}}" target="_blank" rel="noopener">{{author.website}}</a><br>{{/if}}
-      {{#if author.location}}<i class="fa fa-fw fa-map-marker"></i> {{author.location}}{{/if}}
+      {{#if primary_author.website}}<i class="fa fa-fw fa-globe"></i> <a href="{{primary_author.website}}" target="_blank" rel="noopener">{{primary_author.website}}</a><br>{{/if}}
+      {{#if primary_author.location}}<i class="fa fa-fw fa-map-marker"></i> {{primary_author.location}}{{/if}}
     </p>
 </section>


### PR DESCRIPTION
All issues based on the [GScan](https://gscan.ghost.org/) check have been fixed.

I have also added empty css classes for the new editor options (see [Ghost Docs](https://docs.ghost.org/api/handlebars-themes/editor/)). Maybe it's worth implementing them correctly for further usage ([Vapor](https://github.com/sethlilly/Vapor/pull/64) doesn't use them either).